### PR TITLE
Run grunt `shell` task with `default` task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,6 +61,6 @@ module.exports = function(grunt) {
 
     require('load-grunt-tasks')(grunt);
 
-    grunt.registerTask('default', ['sass', 'autoprefixer', 'browserSync', 'watch']);
+    grunt.registerTask('default', ['shell', 'sass', 'autoprefixer', 'browserSync', 'watch']);
 
 };


### PR DESCRIPTION
Without this the initial run of grunt fails with errors about `output/www` not existing.

Not 100% sure if this is a worthwhile idea, as it does only happen on the initial run of `grunt`, and it can be worked around by manually running `nanoc` anyway.